### PR TITLE
[modify] Pages 説明部分の画像のリンク切れ修正 #4

### DIFF
--- a/domain3/README.md
+++ b/domain3/README.md
@@ -160,7 +160,7 @@ GitHub Pagesについて確認する。
 
 - `foundations-hands-on-2`リポジトリのナビゲーションのSettingsからPagesをONにする  
   - Sourceに「Deploy from branch」を選び、`main`リポジトリの`/(root)`を選択してSaveする
-  - ![github pages](./image/image3-29.png)
+  - ![github pages](../image/image3-29.png)
 - しばらくしてリロードしてみるとURLがでてるのでアクセスする
   - ![access github pages](../image/image3-30.png)
   - READMEの内容が見えることを確認する


### PR DESCRIPTION
This pull request includes a minor change to the `domain3/README.md` file. The change updates the image path for the GitHub Pages section to ensure the image is correctly displayed.

* [`domain3/README.md`](diffhunk://#diff-0209aeb8e531c29ab8f4e4332c0a97ffdf58c4557b70e0cf8d94b65ecb666e36L163-R163): Updated the image path from `./image/image3-29.png` to `../image/image3-29.png` to fix the image display issue.

close #4 