### PR TITLE
Markdown執筆用環境の構築

### DIFF
--- a/.devcontainer/writing/cspell.json
+++ b/.devcontainer/writing/cspell.json
@@ -1,0 +1,7 @@
+{
+  "words": [
+    "Anson",
+    "taichi",
+    "textlint"
+  ]
+}

--- a/.devcontainer/writing/devcontainer.json
+++ b/.devcontainer/writing/devcontainer.json
@@ -9,5 +9,6 @@
         "taichi.vscode-textlint"
       ]
     }
-  }
+  },
+  "onCreateCommand": "bash ./.devcontainer/writing/scripts/onCreateCommand.sh"
 }

--- a/.devcontainer/writing/devcontainer.json
+++ b/.devcontainer/writing/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "image":"mcr.microsoft.com/devcontainers/universal:2",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "DavidAnson.vscode-markdownlint",
+        "GitHub.copilot",
+        "streetsidesoftware.code-spell-checker",
+        "taichi.vscode-textlint"
+      ]
+    }
+  }
+}

--- a/.devcontainer/writing/scripts/onCreateCommand.sh
+++ b/.devcontainer/writing/scripts/onCreateCommand.sh
@@ -1,0 +1,4 @@
+npm install -g \
+  textlint \
+  textlint-rule-preset-japanese \
+  textlint-rule-preset-ja-technical-writing

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,8 @@
+{
+  "plugins": {},
+  "filters": {},
+  "rules": {
+    "preset-ja-technical-writing": true,
+    "preset-japanese": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "devcontainers",
+    "octocat"
+  ]
+}


### PR DESCRIPTION
Markdownで執筆する際に便利な拡張機能をインストールしたdevcontainer環境です。

- Markdown linter (`DavidAnson.vscode-markdownlint`)
- Spell checker (`streetsidesoftware.code-spell-checker`)
- Text linter (`taichi.vscode-textlint`)
  - 日本語のプラグイン（`textlint-rule-preset-japanese`, `textlint-rule-preset-ja-technical-writing`）

`writing`サブディレクトリに格納しています。Codespaces起動時は、オプションから起動します。